### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask==3.0.0
 pytest==7.4.0
+openai


### PR DESCRIPTION
Azure deployment was unsuccessful in Github Actions due to "No module named openai" error. This was an attempt to try to fix this issue by adding "openai" to the requirements.txt file